### PR TITLE
Use all available animations

### DIFF
--- a/source/MoeMascot.cpp
+++ b/source/MoeMascot.cpp
@@ -420,15 +420,16 @@ MoeMascot::MoveToPrefered(void)
 void
 MoeMascot::Wink(void)
 {
-  BList winkAnimes;
-
   delete mWinkTrigger;
   mWinkTrigger = NULL;
-  BInvoker *reply = new BInvoker(new BMessage(MOE_WINK_DONE), this);
-  this->FindAnimesMatch(&winkAnimes, "WINK");
-  reinterpret_cast<MoeAnime*>
-    (winkAnimes.ItemAt(MoeUtils::Rand(winkAnimes.CountItems())))
-    ->Play(reply);
+  MoeAnime *anime = AnimeAt(MoeUtils::Rand(CountAnimes()));
+  if (anime != NULL)
+    {
+      BInvoker *reply = new BInvoker(new BMessage(MOE_WINK_DONE), this);
+      anime->Play(reply);
+    }
+  else
+    WinkDone();
 }
 
 


### PR DESCRIPTION
There's no point in filtering by WINK name, given that the command allows adding animations with any name and there is no other type now.

Also protect agains the possibility of `MoeUtils::Rand(int32 max)` returning `max`.

Fixes #8